### PR TITLE
Added vi mode indicator

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -166,6 +166,23 @@ function __lucid_git_status
     set_color normal
 end
 
+function __lucid_vi_indicator
+    if [ $fish_key_bindings = "fish_vi_key_bindings" ]
+        switch $fish_bind_mode
+            case "insert"
+                set_color green
+                echo -n "[I] "
+            case "default"
+                set_color red
+                echo -n "[N] "
+            case "visual"
+                set_color yellow
+                echo -n "[S] "
+        end
+        set_color normal
+    end
+end
+
 function fish_prompt
     set -l cwd (pwd | string replace "$HOME" '~')
 
@@ -181,5 +198,7 @@ function fish_prompt
         end
     end
 
-    echo -en "\n$lucid_prompt_symbol "
+    echo ''
+    __lucid_vi_indicator
+    echo -n "$lucid_prompt_symbol "
 end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -183,6 +183,10 @@ function __lucid_vi_indicator
     end
 end
 
+# Suppress default mode prompt
+function fish_mode_prompt
+end
+
 function fish_prompt
     set -l cwd (pwd | string replace "$HOME" '~')
 


### PR DESCRIPTION
Fixes #2

Added vi mode indicator for `fish_vi_key_bindings`. When using `fish_default_key_bindings` indicator is off. You can see all possible states on the screenshot.

![2020-10-27-105717_1920x1080_scrot](https://user-images.githubusercontent.com/16033061/97272957-8bea1900-182a-11eb-9d98-c1476bbf2f75.png)
