### PR TITLE
[WIP Do not merge] Add git ahead and behind indicators

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -230,7 +230,10 @@ function fish_prompt
     set status_line (__lucid_status_line)
 
     echo -n $status_line
-    set spaces (math $COLUMNS - (string length "$status_line"))
+
+    # Removes color sequences
+    set raw_status (echo $status_line | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | sed 's/\(\x1B(B\x1B\[m\)//g')
+    set spaces (math $COLUMNS - (string length "$raw_status"))
     string repeat -n $spaces " "
 
     __lucid_vi_indicator

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -54,7 +54,12 @@ function __lucid_git_behind_ahead
     set current_status (git status --branch --porcelain 2> /dev/null)
     set ahead (echo $current_status | grep -oE "ahead [0-9]+" | awk '{print $2}')
     set behind (echo $current_status | grep -oE "behind [0-9]+" | awk '{print $2}')
-    echo -n "$lucid_git_ahead_indicator$ahead $lucid_git_behind_indicator$behind"
+    if test -n "$ahead"
+        echo -n "$lucid_git_ahead_indicator$ahead "
+    end
+    if test -n "$behind"
+        echo -n "$lucid_git_behind_indicator$behind"
+    end
 end
 
 function __lucid_git_status

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -7,6 +7,14 @@ if ! set -q lucid_prompt_symbol
     set -g lucid_prompt_symbol "❯"
 end
 
+if ! set -q lucid_git_ahead_indicator
+    set -g lucid_git_ahead_indicator "↑"
+end
+
+if ! set -q lucid_git_behind_indicator
+    set -g lucid_git_behind_indicator "↓"
+end
+
 # This should be set to be at least as long as lucid_dirty_indicator, due to a fish bug
 if ! set -q lucid_clean_indicator
     set -g lucid_clean_indicator (string replace -r -a '.' ' ' $lucid_dirty_indicator)
@@ -40,6 +48,13 @@ function __lucid_abort_check
         command kill $pid >/dev/null 2>&1
         set -e __lucid_check_pid
     end
+end
+
+function __lucid_git_behind_ahead
+    set current_status (git status --branch --porcelain 2> /dev/null)
+    set ahead (echo $current_status | grep -oE "ahead [0-9]+" | awk '{print $2}')
+    set behind (echo $current_status | grep -oE "behind [0-9]+" | awk '{print $2}')
+    echo -n "$lucid_git_ahead_indicator$ahead $lucid_git_behind_indicator$behind"
 end
 
 function __lucid_git_status
@@ -154,6 +169,9 @@ function __lucid_git_status
     # Render git status. When in-progress, use previous state to reduce flicker.
     set_color $lucid_git_color
     echo -n $__lucid_git_static ''
+
+    __lucid_git_behind_ahead
+    echo -n ' '
 
     if ! test -z $__lucid_dirty
         echo -n $__lucid_dirty

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -210,10 +210,9 @@ end
 function fish_mode_prompt
 end
 
-function fish_prompt
+function __lucid_status_line
     set -l cwd (pwd | string replace "$HOME" '~')
 
-    echo ''
     set_color $lucid_cwd_color
     echo -sn $cwd
     set_color normal
@@ -224,8 +223,16 @@ function fish_prompt
             echo -sn " on $git_state"
         end
     end
+end
 
+function fish_prompt
     echo ''
+    set status_line (__lucid_status_line)
+
+    echo -n $status_line
+    set spaces (math $COLUMNS - (string length "$status_line"))
+    string repeat -n $spaces " "
+
     __lucid_vi_indicator
     echo -n "$lucid_prompt_symbol "
 end


### PR DESCRIPTION
I want to add git indicators for ahead and behind. At the moment they look like on the screenshot. Currently they are displayed even if there are no commits ahead and behind - this behavior needs to be fixed. Also I know, that with dirty check you make some optimizations and this currently runs `git status` on each redraw.

Want to hear your feedback on how you think it should look and behave.

![2020-10-29-123448_1920x1080_scrot](https://user-images.githubusercontent.com/16033061/97551016-57ad5e80-19ca-11eb-9f9f-dfba4e503711.png)
