### PR TITLE
Added replace mode to the vi mode indicator

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -178,6 +178,9 @@ function __lucid_vi_indicator
             case "visual"
                 set_color yellow
                 echo -n "[S] "
+            case "replace"
+                set_color blue
+                echo -n "[R] "
         end
         set_color normal
     end


### PR DESCRIPTION
Hi,

I've been using your prompt and realized that It's missing the replace mode indicator of vi.
Here you can see how it looks:

![link](https://0x0.st/iCXB.png)