### PR TITLE
Optionally show Git status in home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This information is memoized to avoid re-computation during prompt redraws, whic
 * `lucid_clean_indicator`: displayed when a repository is clean. Should be at least as long as `lucid_dirty_indicator` to work around a fish bug. Default: ` ` (a space)
 * `lucid_cwd_color`: color used for current working directory. Default: `green`
 * `lucid_git_color`: color used for git information. Default: `blue`
+* `lucid_git_status_in_home_directory`: if set, git information is also
+   displayed in the home directory. Default: not set
 
 ## Design
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -198,7 +198,7 @@ function fish_prompt
     echo -sn $cwd
     set_color normal
 
-    if test $cwd != '~'
+    if test $cwd != '~'; or test -n "$lucid_git_status_in_home_directory"
         set -l git_state (__lucid_git_status)
         if test $status -eq 0
             echo -sn " on $git_state"


### PR DESCRIPTION
Currently, the Git Status isn't displayed if the current working directory is the home directory (`~`).

Like some other people, I track my dotfiles in Git, so it's handy to be able to see the Git status in the home directory as well.

This adds a new variable `lucid_git_status_in_home_directory`. If set, the Git status will also be displayed in the home directory.