### PR TITLE
Optionally skip inserting a newline before the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This information is memoized to avoid re-computation during prompt redraws, whic
 * `lucid_clean_indicator`: displayed when a repository is clean. Should be at least as long as `lucid_dirty_indicator` to work around a fish bug. Default: ` ` (a space)
 * `lucid_cwd_color`: color used for current working directory. Default: `green`
 * `lucid_git_color`: color used for git information. Default: `blue`
+* `lucid_skip_newline`: if set, doesn't insert a newline before the prompt.
+   Default: not set
 
 ## Design
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -193,7 +193,10 @@ end
 function fish_prompt
     set -l cwd (pwd | string replace "$HOME" '~')
 
-    echo ''
+    if test -z "$lucid_skip_newline"
+        echo ''
+    end
+
     set_color $lucid_cwd_color
     echo -sn $cwd
     set_color normal


### PR DESCRIPTION
Currently, a newline is always inserted before the prompt. This might not always be desirable.

This adds a new variable `lucid_skip_newline`. If set, that newline won't be inserted.