### PR TITLE
Add more customization options to the prompt symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ This information is memoized to avoid re-computation during prompt redraws, whic
 * `lucid_clean_indicator`: displayed when a repository is clean. Should be at least as long as `lucid_dirty_indicator` to work around a fish bug. Default: ` ` (a space)
 * `lucid_cwd_color`: color used for current working directory. Default: `green`
 * `lucid_git_color`: color used for git information. Default: `blue`
+* `lucid_prompt_symbol`: the prompt symbol. Default: `❯`
+* `lucid_prompt_symbol_error`: the prompt symbol when an error occurs.
+   Default: `❯`
+* `lucid_prompt_symbol_color`: the color of the prompt symbol.
+   Default: `$fish_color_normal`
+* `lucid_prompt_symbol_error_color`: the color of the prompt symbol when an
+   error occurs. Default: `$fish_color_normal`
 
 ## Design
 

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -7,6 +7,18 @@ if ! set -q lucid_prompt_symbol
     set -g lucid_prompt_symbol "❯"
 end
 
+if ! set -q lucid_prompt_symbol_error
+    set -g lucid_prompt_symbol_error "❯"
+end
+
+if ! set -q lucid_prompt_symbol_color
+    set -g lucid_prompt_symbol_color "$fish_color_normal"
+end
+
+if ! set -q lucid_prompt_symbol_error_color
+    set -g lucid_prompt_symbol_error_color "$fish_color_normal"
+end
+
 # This should be set to be at least as long as lucid_dirty_indicator, due to a fish bug
 if ! set -q lucid_clean_indicator
     set -g lucid_clean_indicator (string replace -r -a '.' ' ' $lucid_dirty_indicator)
@@ -191,6 +203,7 @@ function fish_mode_prompt
 end
 
 function fish_prompt
+    set -l last_pipestatus "$pipestatus"
     set -l cwd (pwd | string replace "$HOME" '~')
 
     echo ''
@@ -207,5 +220,19 @@ function fish_prompt
 
     echo ''
     __lucid_vi_indicator
-    echo -n "$lucid_prompt_symbol "
+
+    set -l prompt_symbol "$lucid_prompt_symbol"
+    set -l prompt_symbol_color "$lucid_prompt_symbol_color"
+
+    for status_code in "$last_pipestatus"
+        if test "$status_code" -ne 0
+            set prompt_symbol "$lucid_prompt_symbol_error"
+            set prompt_symbol_color "$lucid_prompt_symbol_error_color"
+            break
+        end
+    end
+
+    set_color "$prompt_symbol_color"
+    echo -n "$prompt_symbol "
+    set_color normal
 end


### PR DESCRIPTION
This allows further prompt symbol customization by adding three new variables:

- `lucid_prompt_symbol_error`: overrides `lucid_prompt_symbol` when an error occurs
- `lucid_prompt_symbol_color`: the color of the prompt symbol
- `lucid_prompt_symbol_error_color`: overrides `lucid_prompt_symbol_color` when an error occurs

I've also added `lucid_prompt_symbol` to the list of variables in the README (the variable already existed, but wasn't documented there).