### PR TITLE
Fix exit code evaluation

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -203,7 +203,7 @@ function fish_mode_prompt
 end
 
 function fish_prompt
-    set -l last_pipestatus "$pipestatus"
+    set -l last_pipestatus $pipestatus
     set -l cwd (pwd | string replace "$HOME" '~')
 
     if test -z "$lucid_skip_newline"
@@ -227,7 +227,7 @@ function fish_prompt
     set -l prompt_symbol "$lucid_prompt_symbol"
     set -l prompt_symbol_color "$lucid_prompt_symbol_color"
 
-    for status_code in "$last_pipestatus"
+    for status_code in $last_pipestatus
         if test "$status_code" -ne 0
             set prompt_symbol "$lucid_prompt_symbol_error"
             set prompt_symbol_color "$lucid_prompt_symbol_error_color"


### PR DESCRIPTION
There is an issue with the prompt customization from #14:

`$pipestatus` can contain multiple (space-delimited) exit codes. If this is the case, we can't store it into a string because that will cause the `for` loop to see it as a single value, causing the evaluation to fail:
```
➜ ls | grep foo
Integer 0 in '0 1' followed by non-digit
~/.config/fish/functions/fish_prompt.fish (line 231): 
        if test "$status_code" -ne 0
           ^
in function 'fish_prompt'
in command substitution
~ on master  
➜ Integer 0 in '0 1' followed by non-digit
~/.config/fish/functions/fish_prompt.fish (line 231): 
        if test "$status_code" -ne 0
           ^
in function 'fish_prompt'
```

This PR fixes that issue.