### PR TITLE
Remove references to 'block' function

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -109,10 +109,6 @@ function __lucid_git_status
             set -l cmd "if test ($check_cmd) != "0"; exit 1; else; exit 0; end"
 
             begin
-                # Defer execution of event handlers by fish for the remainder of lexical scope.
-                # This is to prevent a race between the child process exiting before we can get set up.
-                block -l
-
                 set -g __lucid_check_pid 0
                 command fish --private --command "$cmd" >/dev/null 2>&1 &
                 set -l pid (jobs --last --pid)


### PR DESCRIPTION
This removes the call to `block -l` from the codebase, as it's no longer of use (since some time in 2021) and apparently the function may be removed in the future.

cf. https://github.com/fish-shell/fish-shell/issues/10383#issuecomment-2007455406

I'm submitting this just because I happened to stumble on it and thought I might spare lucid a bug in the future - please do reject the PR if you are more concerned about compatibility with old versions of fish than about future-proofing.